### PR TITLE
Removing reference to Manga CG

### DIFF
--- a/index.html
+++ b/index.html
@@ -536,14 +536,6 @@
               </p>
             </dd>
 
-            <dt><a href="https://www.w3.org/community/bdcomacg/">BD Comics Manga Community Group</a></dt>
-            <dd>
-              <p>
-                Coordination on various on the definition of a different Publication Manifest profile for
-                that particular area of publishing.
-              </p>
-            </dd>
-
             <dt><a href="https://www.w3.org/community/publishingbg/">Publishing Business Group</a></dt>
             <dd>
               <p>


### PR DESCRIPTION
As requested by the AC review, the referenced CG has been closed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/pull/17.html" title="Last updated on May 9, 2023, 12:30 PM UTC (6afe12c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/17/8201e04...6afe12c.html" title="Last updated on May 9, 2023, 12:30 PM UTC (6afe12c)">Diff</a>