### PR TITLE
Updated the EPUB Rec reference dates

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,10 +306,10 @@
               </p>
             </dd>
 
-            <dt><strong>EPUB 3.3</strong> <i class="todo">to be updated when Rec is published</i></dt>
+            <dt><strong>EPUB 3.3</strong></dt>
             <dd>
               <p>
-                Latest publication: 21 February 2023<br>
+                Latest publication: 25 May 2023<br>
                 Exclusion Draft: <a
                   href="https://www.w3.org/TR/2023/CR-epub-33-20230221/">https://www.w3.org/TR/2023/CR-epub-33-20230221/</a><br>
                 Associated <a href="https://lists.w3.org/Archives/Public/public-epub-wg/2023Feb/0014.html">Call
@@ -320,10 +320,10 @@
               </p>
             </dd>
 
-            <dt><strong>EPUB Reading Systems 3.3</strong> <i class="todo">to be updated when Rec is published</i></dt>
+            <dt><strong>EPUB Reading Systems 3.3</strong></dt>
             <dd>
               <p>
-                Latest publication: 21 February 2023<br>
+                Latest publication: 25 May 2023<br>
                 Exclusion Draft: <a
                   href="https://www.w3.org/TR/2023/CR-epub-rs-33-20230221/">https://www.w3.org/TR/2023/CR-epub-rs-33-20230221/</a><br>
                 Associated <a href="https://lists.w3.org/Archives/Public/public-epub-wg/2023Feb/0015.html">Call
@@ -334,11 +334,10 @@
               </p>
             </dd>
 
-            <dt><strong>EPUB Accessibility 1.1</strong> <i class="todo">to be updated when Rec is published</i>
-            </dt>
+            <dt><strong>EPUB Accessibility 1.1</strong></dt>
             <dd>
               <p>
-                Latest publication: 21 February 2023<br>
+                Latest publication: 25 May 2023<br>
                 Exclusion Draft: <a
                   href="https://www.w3.org/TR/2023/CR-epub-a11y-11-20230221/">https://www.w3.org/TR/2023/CR-epub-a11y-11-20230221/</a><br>
                 Associated <a href="https://lists.w3.org/Archives/Public/public-epub-wg/2023Feb/0016.html">Call


### PR DESCRIPTION
Title tells it all: EPUB is published on the 25th of May.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/pull/18.html" title="Last updated on May 24, 2023, 10:16 AM UTC (db58920)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/18/8201e04...db58920.html" title="Last updated on May 24, 2023, 10:16 AM UTC (db58920)">Diff</a>