### PR TITLE
Put class 4 changes out of scope for EPUB 3.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,6 +220,10 @@
             </li>
 
             <li>
+              <a href="https://www.w3.org/2021/Process-20211102/#class-4">Class 4</a> changes to the EPUB 3.3 specifications.
+            </li>
+
+            <li>
               Digital Rights Management (DRM) features for Audiobooks or EPUB Publications.
             </li>
 

--- a/index.html
+++ b/index.html
@@ -222,6 +222,10 @@
             </li>
 
             <li>
+              <a href="https://www.w3.org/2021/Process-20211102/#class-4">Class 4</a> changes to the EPUB 3.3 specifications.
+            </li>
+
+            <li>
               Digital Rights Management (DRM) features for Audiobooks or EPUB Publications.
             </li>
 

--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
               <p>
                 Latest publication: 25 May 2023<br>
                 Exclusion Draft: <a
-                  href="https://www.w3.org/TR/2023/CR-epub-33-20230221/">https://www.w3.org/TR/2023/CR-epub-33-20230221/</a><br>
+                  href="https://www.w3.org/TR/2023/REC-epub-33-20230525/">https://www.w3.org/TR/2023/REC-epub-33-20230525/</a><br>
                 Associated <a href="https://lists.w3.org/Archives/Public/public-epub-wg/2023Feb/0014.html">Call
                   for Exclusion</a> 21 February 2023, ended on 22 April 2023<br>
                 Other Charter: <a
@@ -327,7 +327,7 @@
               <p>
                 Latest publication: 25 May 2023<br>
                 Exclusion Draft: <a
-                  href="https://www.w3.org/TR/2023/CR-epub-rs-33-20230221/">https://www.w3.org/TR/2023/CR-epub-rs-33-20230221/</a><br>
+                  href="https://www.w3.org/TR/2023/REC-epub-rs-33-20230525/">https://www.w3.org/TR/2023/REC-epub-rs-33-20230525/</a><br>
                 Associated <a href="https://lists.w3.org/Archives/Public/public-epub-wg/2023Feb/0015.html">Call
                   for Exclusion</a> 21 February 2023, ended on 22 April 2023<br>
                 Other Charter: <a
@@ -341,7 +341,7 @@
               <p>
                 Latest publication: 25 May 2023<br>
                 Exclusion Draft: <a
-                  href="https://www.w3.org/TR/2023/CR-epub-a11y-11-20230221/">https://www.w3.org/TR/2023/CR-epub-a11y-11-20230221/</a><br>
+                  href="https://www.w3.org/TR/2023/REC-epub-a11y-11-20230525/">https://www.w3.org/TR/2023/REC-epub-a11y-11-20230525/</a><br>
                 Associated <a href="https://lists.w3.org/Archives/Public/public-epub-wg/2023Feb/0016.html">Call
                   for Exclusion</a> 21 February 2023, ended on 22 April 2023<br>
                 Other Charter: <a

--- a/index.html
+++ b/index.html
@@ -75,8 +75,7 @@
 
 
     <main>
-      <h1 id="title">[PROPOSED] Publishing Maintenance Working Group Charter</h1>
-      <!-- delete PROPOSED after AC review completed -->
+      <h1 id="title">Publishing Maintenance Working Group Charter</h1>
 
       <p class="mission">
         The <strong>mission</strong> of the Publishing Maintenance Working is to maintain the W3C Recommendations, as
@@ -86,7 +85,7 @@
       </p>
 
       <div class="noprint">
-        <p class="join todo">
+        <p>
           <a href="https://www.w3.org/groups/wg/pm/join">Join the Publishing Maintenance Working Group.</a>
         </p>
       </div>
@@ -98,7 +97,7 @@
               Charter Status
             </th>
             <td>
-              <span class="todo">See the <a href="https://www.w3.org/groups/wg/pm/charters">group status page</a> and <a
+              <span>See the <a href="https://www.w3.org/groups/wg/pm/charters">group status page</a> and <a
                   href="#history">detailed change history</a>.</span>
             </td>
           </tr>
@@ -107,8 +106,7 @@
               Start date
             </th>
             <td>
-              <i class="todo">[dd monthname yyyy] (date of the "Call for Participation", when the charter is
-                approved)</i>
+              20 June 2023
             </td>
           </tr>
           <tr id="CharterEnd">
@@ -116,7 +114,7 @@
               End date
             </th>
             <td>
-              <i class="todo">[dd monthname yyyy]</i> (Start date + 2 years)
+              30 June 2025
             </td>
           </tr>
           <tr>
@@ -267,7 +265,7 @@
           <a href="https://www.w3.org/groups/wg/publishing/publications">Audiobooks</a> and the
           <a href="https://www.w3.org/groups/wg/epub/publications">EPUB</a> Working Group.
           As new versions are published, the document statuses will become available on the publication list of the
-          <a class="todo" href="https://www.w3.org/groups/wg/pm/publications">Publishing Maintenance</a> Working Group.
+          <a href="https://www.w3.org/groups/wg/pm/publications">Publishing Maintenance</a> Working Group.
         </p>
 
         <section id="normative">
@@ -792,13 +790,13 @@
               </tbody>
               <tr>
                 <th>
-                  <a class="todo" href="">Initial Charter</a>
+                  <a href="https://www.w3.org/2023/06/pmwg-charter.html">Initial Charter</a>
                 </th>
                 <td>
-                  <i class="todo">[dd monthname yyyy]</i>
+                  20 June 2023
                 </td>
                 <td>
-                  <i class="todo">[dd monthname yyyy]</i>
+                  30 June 2025
                 </td>
                 <td>
 

--- a/index.html
+++ b/index.html
@@ -306,10 +306,10 @@
               </p>
             </dd>
 
-            <dt><strong>EPUB 3.3</strong> <i class="todo">to be updated when Rec is published</i></dt>
+            <dt><strong>EPUB 3.3</strong></dt>
             <dd>
               <p>
-                Latest publication: 21 February 2023<br>
+                Latest publication: 25 May 2023<br>
                 Exclusion Draft: <a
                   href="https://www.w3.org/TR/2023/CR-epub-33-20230221/">https://www.w3.org/TR/2023/CR-epub-33-20230221/</a><br>
                 Associated <a href="https://lists.w3.org/Archives/Public/public-epub-wg/2023Feb/0014.html">Call
@@ -320,10 +320,10 @@
               </p>
             </dd>
 
-            <dt><strong>EPUB Reading Systems 3.3</strong> <i class="todo">to be updated when Rec is published</i></dt>
+            <dt><strong>EPUB Reading Systems 3.3</strong></dt>
             <dd>
               <p>
-                Latest publication: 21 February 2023<br>
+                Latest publication: 25 May 2023<br>
                 Exclusion Draft: <a
                   href="https://www.w3.org/TR/2023/CR-epub-rs-33-20230221/">https://www.w3.org/TR/2023/CR-epub-rs-33-20230221/</a><br>
                 Associated <a href="https://lists.w3.org/Archives/Public/public-epub-wg/2023Feb/0015.html">Call
@@ -334,11 +334,10 @@
               </p>
             </dd>
 
-            <dt><strong>EPUB Accessibility 1.1</strong> <i class="todo">to be updated when Rec is published</i>
-            </dt>
+            <dt><strong>EPUB Accessibility 1.1</strong></dt>
             <dd>
               <p>
-                Latest publication: 21 February 2023<br>
+                Latest publication: 25 May 2023<br>
                 Exclusion Draft: <a
                   href="https://www.w3.org/TR/2023/CR-epub-a11y-11-20230221/">https://www.w3.org/TR/2023/CR-epub-a11y-11-20230221/</a><br>
                 Associated <a href="https://lists.w3.org/Archives/Public/public-epub-wg/2023Feb/0016.html">Call

--- a/index.html
+++ b/index.html
@@ -536,14 +536,6 @@
               </p>
             </dd>
 
-            <dt><a href="https://www.w3.org/community/bdcomacg/">BD Comics Manga Community Group</a></dt>
-            <dd>
-              <p>
-                Coordination on various on the definition of a different Publication Manifest profile for
-                that particular area of publishing.
-              </p>
-            </dd>
-
             <dt><a href="https://www.w3.org/community/publishingbg/">Publishing Business Group</a></dt>
             <dd>
               <p>


### PR DESCRIPTION
On request by a member comment.

Note: this also reinforces the corresponding <a href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2023-01-27-epub#section3">EPUB Working Group</a> resolution.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/pull/19.html" title="Last updated on Jun 5, 2023, 1:42 PM UTC (9ff228a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/19/8201e04...9ff228a.html" title="Last updated on Jun 5, 2023, 1:42 PM UTC (9ff228a)">Diff</a>