### PR TITLE
Various minor edits

### DIFF
--- a/index.html
+++ b/index.html
@@ -330,7 +330,10 @@
                 </h2>
 
                 <p>
-                    Updated document status is available on the publication list of the
+                    Updated document status is available, initially, on the publication lists of the
+                    <a href="https://www.w3.org/groups/wg/publishing/publications">Audiobooks</a> and the
+                    <a href="https://www.w3.org/groups/wg/epub/publications">EPUB</a> Working Group.
+                    As new versions are published, the document statuses will become available on the publication list of the
                     <a href="https://www.w3.org/groups/wg/pm/publications">Publishing Maintenance</a> Working Group.
                 </p>
 
@@ -338,7 +341,7 @@
                     <h3>
                         Normative Specifications
                     </h3>
-                    <p>
+                    
                     <p>The Working Group will maintain the following W3C normative specifications:</p>
 
                     <dl>

--- a/index.html
+++ b/index.html
@@ -79,14 +79,14 @@
             <!-- delete PROPOSED after AC review completed -->
 
             <p class="mission">
-                The <strong>mission</strong> of the Publishing Maintenance Working Group is to maintain the W3C Recommendations, as
-                well as related Notes, in the area of Digital Publishing, published originally by the <a
+                The <strong>mission</strong> of the Publishing Maintenance Working Group is to maintain the W3C Recommendations 
+            	and related Notes in the area of Digital Publishing. These documents were published originally by the <a
                 href="https://www.w3.org/publishing/groups/publ-wg/">Audiobooks</a> and the <a
                 href="https://www.w3.org/publishing/groups/epub-wg/">EPUB</a> Working Groups.
             </p>
 
             <div class="noprint">
-                <p class="join"><a href="https://www.w3.org/groups/wg/pm/join/">Join the Publishing Maintenance Working Working Group.</a></p>
+                <p class="join"><a href="https://www.w3.org/groups/wg/pm/join/">Join the Publishing Maintenance Working Group.</a></p>
             </div>
 
             <!-- delete the GH link after AC review completed -->
@@ -148,7 +148,7 @@
                             <br>
                             <strong>Face-to-face:</strong> we will meet during the W3C's annual Technical Plenary week;
                              additional face-to-face meetings may be scheduled by consent of the participants, 
-                             usually no more than 3 per year.
+                             usually no more than three per year.
                         </td>
                     </tr>
                 </table>
@@ -158,9 +158,9 @@
             <div id="background" class="background">
                 <h2>Motivation and Background</h2>
                 <p>
-                    In the past few years the Publishing Maintenance Working Group (under its 
+                    For the past few years, the Publishing Maintenance Working Group (under its 
                     <a href="https://www.w3.org/2023/06/pmwg-charter.html">previous charter</a>) 
-                    maintained the specifications originally published by the 
+                    has maintained the specifications originally published by the 
                     <a href="https://www.w3.org/publishing/groups/publ-wg/">Audiobooks Working Group</a> 
                     and the <a href="https://www.w3.org/publishing/groups/epub-wg/">EPUB Working Group</a>. 
                     During that time, comments and issues, as well as industry demands, came to the foreground that the Working Group
@@ -175,9 +175,9 @@
                 <h2>Scope</h2>
                 <p>
                     The Working Group continues to maintain the
-                    <a href="https://www.w3.org/TR/pub-manifest/">Publication Manifest</a>,
-                    <a href="https://www.w3.org/TR/audiobooks/">Audiobooks</a> as
-                    well as related Notes, such as the
+                    <a href="https://www.w3.org/TR/pub-manifest/">Publication Manifest</a> and
+                    <a href="https://www.w3.org/TR/audiobooks/">Audiobooks</a> Recommendations, as well as 
+                	related Notes such as the
                     <a href="https://www.w3.org/TR/lpf/">Lightweight Packaging Format</a>.
                     For these specifications, <a href="https://www.w3.org/policies/process/class-4">class 4</a> changes are allowed.
                 </p>
@@ -233,8 +233,8 @@
                 </p>
                 
                 <p>
-                    The Working Group will also incubate other issues, without necessarily aiming at the creation of final
-                    Recommendations during the lifetime of this charter. These are:
+                    The Working Group will also incubate other issues without necessarily aiming at the creation of final
+                    Recommendations during the lifetime of this charter. These include:
                 </p>
                 
                 <ul>
@@ -247,20 +247,20 @@
                 </ul>
                 
                 <p>
-                    The Working Group may produce a new version of EPUB 3, i.e., EPUB 3.4 or EPUB 3.3.1
-                    (referred to as “EPUB 3.X” in this document), depending on the type of changes.
-                    It is a primary goal of the new EPUB version to remain backward compatible with EPUB 3.3,
-                    i.e., existing conformant EPUB 3.3 would remain conformant EPUB 3.X documents.
+                    The Working Group may produce an updated version of EPUB 3, which is referred to as “EPUB 3.X”
+                    in this document. Depending on the type of changes this could be either EPUB 3.4 or EPUB 3.3.1.
+                    It is a primary goal of the new EPUB version to remain backward compatible with EPUB 3.3
+                    (i.e., existing conformant EPUB 3.3 would remain conformant EPUB 3.X documents).
                 </p>
                 
                 <p>
                     Depending on community discussions and demands, this Working Group may also decide to submit the EPUB 3.X,
-                    the EPUB Reading Systems 3.X, and the EPUB Accessibility 1.1 specifications to
+                    the EPUB Reading Systems 3.X, and the EPUB Accessibility 1.X specifications to
                     <a href="https://www.iso.org/committee/45020.html">ISO/IEC JTC1</a> to be published as ISO/IEC standards.
                     If the decision is to proceed with a submission, this would follow
                     the <a href="https://www.w3.org/2010/03/w3c-pas-submission.html">PAS Submission process</a>.
                     This would obsolete the current ISO/IEC 23736-1-6:2020 standards based on
-                    <a href="https://idpf.org/epub/301/spec/epub-publications.html">EPUB 3.01</a> (originally published in 2014),
+                    <a href="https://idpf.org/epub/301/spec/epub-publications.html">EPUB 3.0.1</a> (originally published in 2014),
                     as well as the separate ISO/IEC 23761:2021 EPUB Accessibility standard.
                     The PAS submission would not affect the current distribution rights of the documents, which will remain free on
                     www.w3.org, and it can also be expected that the documents will be available on the ISO Web site at no costs as
@@ -278,7 +278,7 @@
                 
                 <section id="section-out-of-scope">
                     <h3 id="out-of-scope">Out of Scope</h3>
-                    <p>The following features are out of scope, and will not be addressed by this Working Group group.</p>
+                    <p>The following features are out of scope and will not be addressed by this Working Group:</p>
                 
                     <ul class="out-of-scope">
                         <li>
@@ -330,10 +330,7 @@
                 </h2>
 
                 <p>
-                    Updated document status is available, initially, on the publication lists of the
-                    <a href="https://www.w3.org/groups/wg/publishing/publications">Audiobooks</a> and the
-                    <a href="https://www.w3.org/groups/wg/epub/publications">EPUB</a> Working Group.
-                    As new versions are published, the document statuses will become available on the publication list of the
+                    Updated document status is available on the publication list of the
                     <a href="https://www.w3.org/groups/wg/pm/publications">Publishing Maintenance</a> Working Group.
                 </p>
 
@@ -647,7 +644,7 @@
                         <dd>
                             <p>
                                 The Accessibility Guidelines Working Group develops guidelines to make Web content
-                                accessible for people with disabilities, and is responsible for the development and
+                                accessible for people with disabilities and is responsible for the development and
                                 maintenance of the WCAG series of Recommendations.
                                 The EPUB Accessibility specification is already based on WCAG, and a liaison will be
                                 set up to ensure that any new features in EPUB 3.3, in particular EPUB Accessibility 1.1,
@@ -782,10 +779,10 @@
                     Participation
                 </h2>
                 <p>
-                    To be successful, this Working Group is expected to have 6 or more
+                    To be successful, this Working Group is expected to have six or more
                     active participants for its duration, including representatives from the key implementors of this
                     specification, and active Editors and Test Leads for each specification. The Chairs, specification
-                    Editors, and Test Leads are expected to contribute half of a working day per week towards the Working|Interest Group. There is no minimum requirement for other
+                    Editors, and Test Leads are expected to contribute half of a working day per week towards the Working Group. There is no minimum requirement for other
                     Participants.
                 </p>
                 <p>
@@ -823,7 +820,7 @@
                 </p>
                 <p>
                     Most Publishing Maintenance Working Group teleconferences will
-                    focus on discussion of particular specifications, and will be conducted on an as-needed basis.
+                    focus on discussion of particular specifications and will be conducted on an as-needed basis.
                 </p>
         <p>
             This group primarily conducts its technical work on <a id="public-github"
@@ -981,7 +978,7 @@
                     </tr>
                     <tr>
                         <th>
-                            Development of a new charter</a>
+                            Development of a new charter
                         </th>
                         <td>
                             2024-10-03
@@ -1003,7 +1000,7 @@
                     <h3>Change log</h3>
 
                     <!-- Use this section for changes _after_ the charter was approved by the Director. -->
-                    <p>Changes to this document are documented in this section.</p>
+                    <p>Changes to this charter are documented in this section.</p>
                     <!--
           <dl id='changes'>
             <dt>YYYY-MM-DD</dt>


### PR DESCRIPTION
Most of these edits are just minor grammatical stuff. I only have a few minor comments to go along with them:

- I split the mission statement at the top as it's a bit of a run-on from the mission itself into who produced the documents.
- The charter talks about submitting 3.X documents to ISO, but then specifically calls out Accessibility 1.1. Is there no chance we produce a 1.X under this new charter? I put it to 1.X for now to match the others, but maybe this has to be reverted.
- The Deliverables section looked like a copy from the old charter as it was still talking about document statuses being posted to the old working group lists. Maybe check that my deletion there makes sense.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/pull/24.html" title="Last updated on Oct 7, 2024, 8:40 AM UTC (78087ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/24/521122f...78087ac.html" title="Last updated on Oct 7, 2024, 8:40 AM UTC (78087ac)">Diff</a>