### PR TITLE
Clarify the lead-in to the deliverables section

### DIFF
--- a/index.html
+++ b/index.html
@@ -330,7 +330,7 @@
                 </h2>
 
             	<p>
-            		The current status of publications updated/published by the Publishing Maintenance Working Group are
+            		The current status of publications updated/published by the Publishing Maintenance Working Group is
             		available on the <a href="https://www.w3.org/groups/wg/pm/publications">publication list</a> of the
             		group. (Non-updated documents remain on the publication lists of the
             		<a href="https://www.w3.org/groups/wg/publishing/publications">Audiobooks</a>

--- a/index.html
+++ b/index.html
@@ -329,14 +329,14 @@
                     Deliverables
                 </h2>
 
-                <p>
-                    Updated document status is available, initially, on the publication lists of the
-                    <a href="https://www.w3.org/groups/wg/publishing/publications">Audiobooks</a> and the
-                    <a href="https://www.w3.org/groups/wg/epub/publications">EPUB</a> Working Group.
-                    As new versions are published, the document statuses will become available on the publication list of the
-                    <a href="https://www.w3.org/groups/wg/pm/publications">Publishing Maintenance</a> Working Group.
-                </p>
-
+            	<p>
+            		The current status of publications updated/published by the Publishing Maintenance Working Group are
+            		available on the <a href="https://www.w3.org/groups/wg/pm/publications">publication list</a> of the
+            		group. (Non-updated documents remain on the publication lists of the
+            		<a href="https://www.w3.org/groups/wg/publishing/publications">Audiobooks</a>
+            		and <a href="https://www.w3.org/groups/wg/epub/publications">EPUB</a> Working Groups.)
+            	</p>
+            	
                 <section id="normative">
                     <h3>
                         Normative Specifications


### PR DESCRIPTION
After some offline discussion with @iherman, this pr modifies the first paragraph to hopefully make it a little easier to understand why document statuses are found in different groups' lists.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/pull/25.html" title="Last updated on Oct 8, 2024, 1:42 PM UTC (9eeac7f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/25/65df8c1...9eeac7f.html" title="Last updated on Oct 8, 2024, 1:42 PM UTC (9eeac7f)">Diff</a>