### PR TITLE
Go for the classical route for Rec

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,9 +228,9 @@
                     </li>
                 </ul>
 
-                <p class="issue">It is unclear to me at this point whether we want to go through classical
+                <!-- <p class="issue">It is unclear to me at this point whether we want to go through classical
                      FPWD->WF->CR->PR->Rec route or whether we settle everything via the Candidate Correction/Addition route of the process. It may depend on the specific feature. Something ought to be here in the scope I guess.
-                </p>
+                </p> -->
                 
                 <p>
                     The Working Group will also incubate other issues without necessarily aiming at the creation of final
@@ -548,12 +548,10 @@
                 
                 <section id="timeline">
                     <h3>Timeline</h3>
-                    <p class="issue">This may need further thoughts.</p>
                     <ul>
                         <li>TBD + 1 week: First teleconference</li>
-                        <li>TBD + 6 months: First drafts (FPWD and/or Candidate Additions) for in-scope changes</li>
-                        <li>TBD + 18 months: CR for a new version (if applicable)</li>
-                        <li>TBD + 18 months: Final CR Snapshot (if applicable)</li>
+                        <li>TBD + 6 months: FPWD for in-scope changes</li>
+                        <li>TBD + 12 months: First CR snapshot for a new version</li>
                         <li>TBD + 24: EPUB 3.X final version</li>
                     </ul>
                 </section>


### PR DESCRIPTION
There was an issue in the text:

> It is unclear to me at this point whether we want to go through classical  FPWD->WF->CR->PR->Rec route or whether we settle everything via the Candidate Correction/Addition route of the process. It may depend on the specific feature. Something ought to be here in the scope I guess.

I propose to remove this from the charter altogether; I have also modified the timeline to clearly refer to an FPWD.

Why? I believe the specification of the annotation feature may be relatively complex, and may require several iterations; I do not think it is a good idea if a Recommendation (even if it is clearly marked as one with candidate additions) is published with that extent of new changes. It may be a problem for the community; a FPWD and then a series of WDs/CRs is cleaner. If we can make it quick: all the better for us!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/pull/28.html" title="Last updated on Oct 8, 2024, 3:16 PM UTC (86df2f6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/28/65df8c1...86df2f6.html" title="Last updated on Oct 8, 2024, 3:16 PM UTC (86df2f6)">Diff</a>