### PR TITLE
Removing ambiguity on EPUB versioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,15 +247,14 @@
                 </ul>
                 
                 <p>
-                    The Working Group may produce an updated version of EPUB 3, which is referred to as “EPUB 3.X”
-                    in this document. Depending on the type of changes this could be either EPUB 3.4 or EPUB 3.3.1.
-                    It is a primary goal of the new EPUB version to remain backward compatible with EPUB 3.3
-                    (i.e., existing conformant EPUB 3.3 would remain conformant EPUB 3.X documents).
+                    The Working Group may produce an updated version of EPUB 3, which is referred to as “EPUB 3.4”
+                    in this document. It is a primary goal of the new EPUB version to remain backward compatible with EPUB 3.3
+                    (i.e., existing conformant EPUB 3.3 would remain conformant EPUB 3.4 documents).
                 </p>
                 
                 <p>
-                    Depending on community discussions and demands, this Working Group may also decide to submit the EPUB 3.X,
-                    the EPUB Reading Systems 3.X, and the EPUB Accessibility 1.X specifications to
+                    Depending on community discussions and demands, this Working Group may also decide to submit the EPUB 3.4,
+                    the EPUB Reading Systems 3.4, and the EPUB Accessibility 1.x specifications to
                     <a href="https://www.iso.org/committee/45020.html">ISO/IEC JTC1</a> to be published as ISO/IEC standards.
                     If the decision is to proceed with a submission, this would follow
                     the <a href="https://www.w3.org/2010/03/w3c-pas-submission.html">PAS Submission process</a>.
@@ -282,7 +281,7 @@
                 
                     <ul class="out-of-scope">
                         <li>
-                            Removal of any existing features defined by EPUB 3.X.
+                            Removal of any existing features defined by EPUB 3.
                             Existing features will only be deprecated if they are not needed to support existing EPUB 3
                             content, as stated in
                             <a href="https://www.w3.org/TR/html-design-principles/#support-existing-content">HTML’s design


### PR DESCRIPTION
We had some ambiguity about version of the spec after we work on these projects, I think we should settle on EPUB 3.4 for clarity and considering the scope of potential changes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/pull/32.html" title="Last updated on Oct 11, 2024, 3:31 PM UTC (e63c747)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/32/432a7ff...e63c747.html" title="Last updated on Oct 11, 2024, 3:31 PM UTC (e63c747)">Diff</a>