### PR TITLE
Adding a reference to the A11y TF output

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,8 +221,8 @@
                         Explicitly define the relationship between the <code>&lt;script&gt;</code> element (including resources used by the referenced scripts) and exempt resources, for example in view of the inclusion of Web Assembly (<code>.wasm</code>) content in EPUB. See (postponed) 
                         <a href="https://github.com/w3c/epub-specs/pull/2655">EPUB Pull Request</a> for further details.
                     </li>
-                    <li class="issue">
-                        Are there any evolution in A11y that we want to put here?
+                    <li>
+                        Work with the Publishing CG's <a href="https://github.com/w3c/publ-a11y/">accessibility task force</a> to incorporate incubated features.
                     </li>
                 </ul>
 


### PR DESCRIPTION
This should fix #35.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/pull/36.html" title="Last updated on Oct 14, 2024, 2:23 PM UTC (e4a871f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/36/7e505e3...e4a871f.html" title="Last updated on Oct 14, 2024, 2:23 PM UTC (e4a871f)">Diff</a>