### PR TITLE
"may produce" -> "will produce" for EPUB 3.4

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,7 +245,7 @@
                 </ul>
                 
                 <p>
-                    The Working Group may produce an updated version of EPUB 3, which is referred to as “EPUB 3.4”
+                    The Working Group will produce an updated version of EPUB 3, which is referred to as “EPUB 3.4”
                     in this document. It is a primary goal of the new EPUB version to remain backward compatible with EPUB 3.3
                     (i.e., existing conformant EPUB 3.3 would remain conformant EPUB 3.4 documents).
                 </p>


### PR DESCRIPTION
"may" seems to be too uncertain for a charter text...


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/pull/38.html" title="Last updated on Oct 17, 2024, 2:41 PM UTC (a015fdf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/38/7e505e3...a015fdf.html" title="Last updated on Oct 17, 2024, 2:41 PM UTC (a015fdf)">Diff</a>