### PR TITLE
Changing the metadata entry in "out of scope"

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,6 +315,10 @@
                             the <a href="https://www.w3.org/TR/lpf/">Lightweight Packaging</a> or the <a
                                 href='https://www.w3.org/TR/epub-33/#sec-ocf'>EPUB Open Container formats</a>, respectively.
                         </li>
+
+                        <li>
+                            Any new metadata that can be deferred to more appropriate Working Groups or external standards organizations.
+                        </li>
                 
                         <li>
                             Any new elements, attributes, properties, or values that would create a fork from Open Web

--- a/index.html
+++ b/index.html
@@ -305,11 +305,7 @@
                         <li>
                             Digital Rights Management (DRM) features for Audiobooks or EPUB Publications.
                         </li>
-                
-                        <li>
-                            New metadata vocabularies.
-                        </li>
-                
+                           
                         <li>
                             New document identification schemes (i.e., alternatives to DOI or ISBN).
                         </li>


### PR DESCRIPTION
See WG discussion: https://w3c.github.io/pm-wg/minutes/2024-11-01.html#metadata


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/pull/46.html" title="Last updated on Nov 6, 2024, 3:43 PM UTC (6d4c3cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/46/6d74347...6d4c3cd.html" title="Last updated on Nov 6, 2024, 3:43 PM UTC (6d4c3cd)">Diff</a>