### PR TITLE
Add text to background section to mention accessibility legislation

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
                     The Publishing Maintenance Working Group also plays a role in supporting the broader
                     publishing community in developing guidance and resources in response to changes in 
                     international accessibility legislation. This includes publishing Working Group Notes 
-                    in response to legislation such as the European Accessibility Act (EAA), or to provide 
+                    in response to legislation such as the European Accessibility Act (EAA) or Americans with Disabilities Act (ADA), and to provide 
                     guidance on how EPUB relates to commonly referenced standards like <a href="https://www.w3.org/TR/WCAG22">WCAG</a>.
                 </p>
                 <p>
@@ -216,7 +216,8 @@
 
                     <li>
                         Work with the Publishing CG's <a href="https://github.com/w3c/publ-a11y/">accessibility
-                        task force</a> to incorporate incubated features.
+                        task force</a> to incorporate incubated features or requirements from legislative changes 
+                        relating to accessibility and publishing.
                     </li>
                 </ul>
 

--- a/index.html
+++ b/index.html
@@ -168,6 +168,15 @@
                     and the <a href="https://www.w3.org/publishing/groups/epub-wg/">EPUB Working Group</a>.
                     During that time new features and demands were put forward by the publishing community that the
                     Working Group was not chartered to answer.
+                </p>
+                <p>
+                    The Publishing Maintenance Working Group also plays a role in supporting the broader
+                    publishing community in developing guidance and resources in response to changes in 
+                    international accessibility legislation. This includes publishing Working Group Notes 
+                    in response to legislation such as the European Accessibility Act (EAA), or to provide 
+                    guidance on how EPUB relates to commonly referenced standards like <a href="https://www.w3.org/TR/WCAG22">WCAG</a>.
+                </p>
+                <p>
                     This charter extends the previous charter by adding features to incrementally improve
                     these Recommendations based on industry demands, provide stable satellite specifications in the
                     form of Working Group Notes, or to provide the base for building the next major revisions of the

--- a/index.html
+++ b/index.html
@@ -216,8 +216,10 @@
 
                     <li>
                         Work with the Publishing CG's <a href="https://github.com/w3c/publ-a11y/">accessibility
-                        task force</a> to incorporate incubated features or requirements from legislative changes 
-                        relating to accessibility and publishing.
+                        task force</a> to incorporate incubated features.
+                    </li>
+                    <li>
+                        Develop guidance to help publishers understand legislated ebook accessibility requirements, as appropriate.
                     </li>
                 </ul>
 


### PR DESCRIPTION
My attempt to include some text to contextualize our relationship to accessibility legislation. 

Feedback more than welcome!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/pull/47.html" title="Last updated on Nov 4, 2024, 4:53 PM UTC (353aa6f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/47/a7c84f0...353aa6f.html" title="Last updated on Nov 4, 2024, 4:53 PM UTC (353aa6f)">Diff</a>