### PR TITLE
Removal of the liaison to the Sync MM for publication CG

### DIFF
--- a/index.html
+++ b/index.html
@@ -717,16 +717,6 @@
                                 Working Group Notes.
                             </p>
                         </dd>
-                
-                        <dt><a href="https://www.w3.org/community/sync-media-pub/">Synchronized Multimedia for Publications
-                                Community Group</a></dt>
-                        <dd>
-                            <p>
-                                Coordination on new synchronized multimedia features and on way they would interoperate with
-                                audiobooks and/or EPUB 3 publications.
-                            </p>
-                            <p class="issue">Check whether this CG is still active, otherwise remove it from the list.</p>
-                        </dd>
 
                         <dt><a href="https://www.w3.org/community/tdmrep/">Text and Data Mining Reservation Protocol Community Group</a></dt>
                         <dd>


### PR DESCRIPTION
The CG is in the process of being closed, so there is no reason to keep this in the list.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/pull/49.html" title="Last updated on Nov 6, 2024, 3:59 PM UTC (e8f981d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/49/4c1e241...e8f981d.html" title="Last updated on Nov 6, 2024, 3:59 PM UTC (e8f981d)">Diff</a>