### PR TITLE
Added references to synched media.

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,6 +258,9 @@
                         areas where the content cannot currently meet WCAG requirements.
                     </li>
                     <li>
+                        Address issues related to the evolution of synchronized media in publishing, including the usage of technologies like <a href="https://www.w3.org/TR/webvtt1/">WebVTT</a>.
+                    </li>
+                    <li>
                         Address security or privacy issues that may arise and require changes in a Recommendation.
                     </li>
                 </ul>
@@ -575,6 +578,7 @@
                     <h3>Timeline</h3>
                     <ul>
                         <li>TBD + 1 week: First teleconference</li>
+                        <li>TBD + 2 months: First F2F meeting</li>
                         <li>TBD + 6 months: FPWD for in-scope changes</li>
                         <li>TBD + 12 months: First CR snapshot for a new version</li>
                         <li>TBD + 24: EPUB 3.X final version</li>
@@ -726,6 +730,13 @@
                                 The goal of this Group is to facilitate Text and Data Mining (TDM) Reservation Protocol, by
                                 specifying a simple and practical machine-readable solution, capable of expressing the reservation of TDM rights. 
                                 Expressing these rights for an EPUB publications is an important part of the Reservation Protocol.
+                            </p>
+                        </dd>
+                        <dt><a href="https://www.w3.org/AudioVideo/TT/">Timed Text Working Group</a></dt>
+                        <dd>
+                            <p>
+                                The Timed Text Working Group maintains the <a href="https://www.w3.org/TR/webvtt1/">WebVTT specification</a>, which may be reused
+                                by EPUB 3.4 as part of the incubation on synchronized media.
                             </p>
                         </dd>
                     </dl>


### PR DESCRIPTION
As discussed at the WG meeting: https://w3c.github.io/pm-wg/minutes/2024-12-06.html.

I have also added a liaison statement to the timed text WG, which maintains WebVTT.

As a separate entry, the _possibility_ to hold a F2F meeting in spring '25 has also been added.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/pull/54.html" title="Last updated on Dec 6, 2024, 3:28 PM UTC (33e54f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/54/1622ee6...33e54f8.html" title="Last updated on Dec 6, 2024, 3:28 PM UTC (33e54f8)">Diff</a>