### PR TITLE
Introduced Accessibility 1.2 as a term.

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,8 +271,9 @@
                 </ul>
                 
                 <p>
-                    As a result of this work, the Working Group will produce an updated version of EPUB 3,
-                    referred to as “EPUB 3.4” and “EPUB Accessibility 1.2” in this document. It is a primary goal of the new EPUB version to
+                    As a result, the Working Group will produce an updated version of EPUB 3 and its accessibility guidelines,
+                    referred to as “EPUB 3.4” and “EPUB Accessibility 1.2”, respectively, in this document.
+                    It is a primary goal of the new EPUB version to
                     remain backward compatible with EPUB 3.3 (i.e., existing conformant EPUB 3.3 would remain
                     conformant EPUB 3.4 documents).
                 </p>
@@ -459,7 +460,7 @@
                         </dd>
 
 
-                        <dt id="epub-a11-11" class="spec"><a href="https://www.w3.org/TR/epub-a11y-11/">EPUB Accessibility 1.1</a></dt>
+                        <dt id="epub-a11-11" class="spec">EPUB Accessibility 1.2</dt>
                        <dd>
                             <p>
                                 This specification specifies content conformance requirements for verifying the accessibility of EPUB® Publications. It

--- a/index.html
+++ b/index.html
@@ -272,14 +272,14 @@
                 
                 <p>
                     As a result of this work, the Working Group will produce an updated version of EPUB 3,
-                    referred to as “EPUB 3.4” in this document. It is a primary goal of the new EPUB version to
+                    referred to as “EPUB 3.4” and “EPUB Accessibility 1.2” in this document. It is a primary goal of the new EPUB version to
                     remain backward compatible with EPUB 3.3 (i.e., existing conformant EPUB 3.3 would remain
                     conformant EPUB 3.4 documents).
                 </p>
                 
                 <p id="isopas">
                     Depending on community discussions and demands, this Working Group may also decide to submit the EPUB 3.4,
-                    the EPUB Reading Systems 3.4, and the EPUB Accessibility 1.x specifications to
+                    the EPUB Reading Systems 3.4, and the EPUB Accessibility 1.2 specifications to
                     <a href="https://www.iso.org/committee/45020.html">ISO/IEC JTC1</a> to be published as ISO/IEC standards.
                     If the decision is to proceed with a submission, this would follow
                     the <a href="https://www.w3.org/2010/03/w3c-pas-submission.html">PAS Submission process</a>.


### PR DESCRIPTION
This is in response to a comment during the AC review process, which was missing an explicit reference to Accessibility 1.2 (alongside EPUB 3.4).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/pull/56.html" title="Last updated on Jan 11, 2025, 10:20 AM UTC (4698744)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-maintenance-wg-charter/56/5d90677...4698744.html" title="Last updated on Jan 11, 2025, 10:20 AM UTC (4698744)">Diff</a>